### PR TITLE
Added improvements to display decoded url parts 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,12 +82,42 @@ function App() {
       </tbody></table>)
   }
 
+  function containsEncodedComponents(x) {
+    // ie ?,=,&,/ etc
+    return (decodeURI(x) !== decodeURIComponent(x));
+  }
+
+  function handleDecoding(key) {
+    // console.log(typeof urlObj[key], key)
+    if (containsEncodedComponents(urlObj[key])) {
+      // console.log("here")
+      return (
+          <tbody className="inner-table">
+            <tr><td>{urlObj[key]}</td></tr>
+            <tr><td><p className="decoded-text">{`decoded`}</p>{decodeURIComponent(urlObj[key])}</td></tr>
+          </tbody>
+      )
+    } else {
+      return (<td>{urlObj[key]}</td>)
+    }
+  }
+
+  function handlePartForTable(key) {
+    if (key === "searchParams") {
+      return (<td>{doSearchParam()}</td>)
+    } else {
+      return handleDecoding(key)
+    }
+
+  }
+
   const allParts = keys.map( (k, i) => {
     if (urlObj[k]) {
       return (
         <tr key={k}>
           <th>{k}</th>
-          {k === "searchParams" ? <td>{doSearchParam()}</td> : <td>{urlObj[k]}</td>}
+          {/* {k === "searchParams" ? <td>{doSearchParam()}</td> : <td>{urlObj[k]}</td>} */}
+          {handlePartForTable(k)}
         </tr>
       )
     }

--- a/src/index.css
+++ b/src/index.css
@@ -54,6 +54,7 @@ table {
 
 .inner-table {
   margin: 0;
+  border: hidden;
 }
 
 th {
@@ -66,6 +67,10 @@ th, td {
   text-align: left;
   /* border: 0.5px solid rgb(190, 212, 235); */
   border: 2px solid rgb(215, 226, 236);
+}
+
+tr {
+  overflow: auto;
 }
 
 td {
@@ -138,4 +143,17 @@ td {
   height: 18px;
   width: 18px;
   padding-right: 5px;
+}
+
+.decoded-text {
+  margin: 2px -2px;
+  margin-right: 8px;
+  padding: 2px 2px;
+  /* border: 0.5px solid lightgray; */
+  border-radius: 20px;
+  width: 70px;
+  text-align: center;
+  background-color: lightgray;
+  display: inline-block;
+  font-size: 12px;
 }


### PR DESCRIPTION
Added a check for if url parts need decoding, and then add a copy of the decoded url part if it has encoding.

![image](https://user-images.githubusercontent.com/69932288/194435391-e112ff18-8a64-4a02-8646-c2258c46360b.png)


Note -- it seems like the search params from the javascript url obj parsing already handles the decoding for the values of the broken out key-value search params property.
